### PR TITLE
Fix issue with old drjit version on new drivers

### DIFF
--- a/ext/drjit/ext/drjit-core/src/init.cpp
+++ b/ext/drjit/ext/drjit-core/src/init.cpp
@@ -189,9 +189,9 @@ void jitc_init(uint32_t backends) {
         device.ptx_version = 60;
 
         const uint32_t sm_table[][2] = { { 70, 60 }, { 72, 61 }, { 75, 63 }, { 80, 70 },
-                                         { 86, 71 }, { 87, 74 }, { 87, 74 }, { 90, 78 } };
+                                         { 86, 71 }, { 89, 78 }, { 90, 78 } };
         uint32_t cc_combined = cc_major * 10 + cc_minor;
-        for (int j = 0; j < 8; ++j) {
+        for (int j = 0; j < 7; ++j) {
             if (cc_combined >= sm_table[j][0]) {
                 device.compute_capability = sm_table[j][0];
                 device.ptx_version = sm_table[j][1];


### PR DESCRIPTION
Thanks for releasing the code! Here is a quick fix I had to do to get it running on newer driver versions.

## Description

The version of drjit used in this project has a known issue with newer drivers: https://github.com/mitsuba-renderer/drjit/issues/165
The issue was fixed in the following commit: https://github.com/mitsuba-renderer/drjit-core/commit/25dd7a5cb96ee58d65cc1499f47de76f6140ff36

This PR just adds the same fix.

## Testing

Tested on driver version 566.14.